### PR TITLE
OffsetOf Fixes

### DIFF
--- a/source/common/utils.h
+++ b/source/common/utils.h
@@ -34,14 +34,6 @@ static T& GetInstance(uintptr_t ptr, uintptr_t init_flag, uintptr_t init_fn) {
   return *instance;
 }
 
-/// Returns the offset in bytes of a member.
-/// Unlike offsetof, this works for derived classes as well.
-template <typename T1, typename T2>
-inline size_t constexpr OffsetOf(T1 T2::*member) {
-  constexpr T2 object{};
-  return size_t(&(object.*member)) - size_t(&object);
-}
-
 template <typename Dest, typename T>
 Dest BitCastPtr(const T* ptr, size_t offset = 0) {
   Dest dest;

--- a/source/game/actor.h
+++ b/source/game/actor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 
 #include "common/bitfield.h"
 #include "common/flags.h"
@@ -244,10 +245,10 @@ struct Actor {
   float field_1F4;
 };
 static_assert(sizeof(Actor) == 0x1F8);
-static_assert(rst::util::OffsetOf(&Actor::field_80) == 0x80);
-static_assert(rst::util::OffsetOf(&Actor::field_B4) == 0xB4);
-static_assert(rst::util::OffsetOf(&Actor::field_F0) == 0xF0);
-static_assert(rst::util::OffsetOf(&Actor::field_11C) == 0x11C);
+static_assert(offsetof(Actor, field_80) == 0x80);
+static_assert(offsetof(Actor, field_B4) == 0xB4);
+static_assert(offsetof(Actor, field_F0) == 0xF0);
+static_assert(offsetof(Actor, field_11C) == 0x11C);
 
 // Name courtesy of the OoT decomp project.
 struct DynaPolyActor : Actor {

--- a/source/game/actors/boss_gyorg.h
+++ b/source/game/actors/boss_gyorg.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 #include "common/types.h"
 #include "game/actor.h"
 #include "game/collision.h"
@@ -107,11 +109,11 @@ struct BossGyorg : Actor {
   int field_F20;
   int field_F24;
 };
-static_assert(rst::util::OffsetOf(&BossGyorg::collision_eye) == 0xAC0);
-static_assert(rst::util::OffsetOf(&BossGyorg::collision_armor) == 0xB30);
-static_assert(rst::util::OffsetOf(&BossGyorg::collision_3) == 0xBF0);
-static_assert(rst::util::OffsetOf(&BossGyorg::collision) == 0xD50);
-static_assert(rst::util::OffsetOf(&BossGyorg::field_EB0) == 0xEB0);
+static_assert(offsetof(BossGyorg, collision_eye) == 0xAC0);
+static_assert(offsetof(BossGyorg, collision_armor) == 0xB30);
+static_assert(offsetof(BossGyorg, collision_3) == 0xBF0);
+static_assert(offsetof(BossGyorg, collision) == 0xD50);
+static_assert(offsetof(BossGyorg, field_EB0) == 0xEB0);
 static_assert(sizeof(BossGyorg) == 0xF28);
 
 }  // namespace game::act

--- a/source/game/actors/boss_twinmold.h
+++ b/source/game/actors/boss_twinmold.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 #include "common/types.h"
 #include "common/utils.h"
 #include "game/actor.h"
@@ -175,7 +177,7 @@ struct BossTwinmold : Actor {
   int field_9624;
 };
 static_assert(sizeof(BossTwinmold) == 0x9628);
-static_assert(rst::util::OffsetOf(&BossTwinmold::other_twinmold_actor) == 0x5E28);
-static_assert(rst::util::OffsetOf(&BossTwinmold::gap_93B0) == 0x93B0);
+static_assert(offsetof(BossTwinmold, other_twinmold_actor) == 0x5E28);
+static_assert(offsetof(BossTwinmold, gap_93B0) == 0x93B0);
 
 }  // namespace game::act

--- a/source/game/as.h
+++ b/source/game/as.h
@@ -2,6 +2,8 @@
 
 // Animation sequence system.
 
+#include <cstddef>
+
 #include "common/types.h"
 #include "common/utils.h"
 
@@ -55,7 +57,7 @@ struct ActorUtil {
   u8 field_8A;
   u8 field_8B;
 };
-static_assert(rst::util::OffsetOf(&ActorUtil::gap_64) == 0x64);
+static_assert(offsetof(ActorUtil, gap_64) == 0x64);
 static_assert(sizeof(ActorUtil) == 0x8C);
 
 }  // namespace game::as

--- a/source/game/common_data.h
+++ b/source/game/common_data.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 
 #include "common/types.h"
 #include "common/utils.h"
@@ -65,7 +66,7 @@ struct __attribute__((packed)) __attribute__((aligned(2))) PlayerData {
   char field_31;
 };
 static_assert(sizeof(PlayerData) == 0x32);
-static_assert(rst::util::OffsetOf(&PlayerData::magic) == 0x1F);
+static_assert(offsetof(PlayerData, magic) == 0x1F);
 
 union FormEquipmentData {
   std::array<ItemId, 5> item_btns;

--- a/source/game/context.h
+++ b/source/game/context.h
@@ -347,15 +347,15 @@ struct GlobalContext : State {
   act::Actor* some_actor;
   u8 gap_F0F4[7996];
 };
-static_assert(rst::util::OffsetOf(&GlobalContext::main_camera) == 0x408);
-static_assert(rst::util::OffsetOf(&GlobalContext::pause_flags) == 0xAAC);
-static_assert(rst::util::OffsetOf(&GlobalContext::elegy_statues) == 0x2394);
-static_assert(rst::util::OffsetOf(&GlobalContext::field_C000) == 0xc000);
-static_assert(rst::util::OffsetOf(&GlobalContext::ocarina_state) == 0x8366);
-static_assert(rst::util::OffsetOf(&GlobalContext::ocarina_song) == 0x836A);
-static_assert(rst::util::OffsetOf(&GlobalContext::hide_hud) == 0x825E);
-static_assert(rst::util::OffsetOf(&GlobalContext::field_836E) == 0x836E);
-static_assert(rst::util::OffsetOf(&GlobalContext::field_C4C8) == 0xC4C8);
+static_assert(offsetof(GlobalContext, main_camera) == 0x408);
+static_assert(offsetof(GlobalContext, pause_flags) == 0xAAC);
+static_assert(offsetof(GlobalContext, elegy_statues) == 0x2394);
+static_assert(offsetof(GlobalContext, field_C000) == 0xc000);
+static_assert(offsetof(GlobalContext, ocarina_state) == 0x8366);
+static_assert(offsetof(GlobalContext, ocarina_song) == 0x836A);
+static_assert(offsetof(GlobalContext, hide_hud) == 0x825E);
+static_assert(offsetof(GlobalContext, field_836E) == 0x836E);
+static_assert(offsetof(GlobalContext, field_C4C8) == 0xC4C8);
 static_assert(sizeof(GlobalContext) == 0x11030);
 
 }  // namespace game

--- a/source/game/pad.h
+++ b/source/game/pad.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 #include "common/flags.h"
 #include "common/types.h"
 #include "common/utils.h"
@@ -123,8 +125,8 @@ struct ControllerMgr {
 };
 #pragma pack(pop)
 static_assert(sizeof(ControllerMgr) == 0x10F0);
-static_assert(rst::util::OffsetOf(&ControllerMgr::state) == 0x1000);
-static_assert(rst::util::OffsetOf(&ControllerMgr::touchscreen_state) == 0x10ED);
+static_assert(offsetof(ControllerMgr, state) == 0x1000);
+static_assert(offsetof(ControllerMgr, touchscreen_state) == 0x10ED);
 
 ControllerMgr& GetControllerMgr();
 

--- a/source/game/player.h
+++ b/source/game/player.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 #include "common/flags.h"
 #include "common/types.h"
 #include "common/utils.h"
@@ -467,9 +469,9 @@ struct Player : public Actor {
   u8 gap_12C48[134];
   s16 field_12CCE;
 };
-static_assert(rst::util::OffsetOf(&Player::transform_mask_action) == 0x200);
-static_assert(rst::util::OffsetOf(&Player::field_12CCE) == 0x12CCE);
-static_assert(rst::util::OffsetOf(&Player::sword_active) == 0x11E3C);
+static_assert(offsetof(Player, transform_mask_action) == 0x200);
+static_assert(offsetof(Player, field_12CCE) == 0x12CCE);
+static_assert(offsetof(Player, sword_active) == 0x11E3C);
 // TODO: complete the struct and add a size assertion.
 
 enum class AllowExistingMagicUsage { No, Yes };


### PR DESCRIPTION
Just recently updated my 3dstools and libctru to see that the implemented OffsetOf no longer works.

```
"/mnt/c/Users/phlex/Projects/project-restoration/source/./game/context.h:358:63: error: non-constant condition for static assertion\n"
"  358 | static_assert(rst::util::OffsetOf(&GlobalContext::field_C4C8) == 0xC4C8);\n"
```
This PR is to change them over to regular `offsetof` calls. It does compile. but there are loads of more warnings during the compilation. I guess having it successfully compile is better than having no warnings, right? 